### PR TITLE
doc changes for pr54 on iter8-analytics

### DIFF
--- a/doc_files/iter8_bookinfo_istio.md
+++ b/doc_files/iter8_bookinfo_istio.md
@@ -121,7 +121,7 @@ spec:
     maxIterations: 8
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold
@@ -221,7 +221,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold
@@ -323,7 +323,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold
@@ -448,7 +448,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_90_perc_latency
         toleranceType: threshold
@@ -611,7 +611,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold

--- a/doc_files/iter8_bookinfo_knative.md
+++ b/doc_files/iter8_bookinfo_knative.md
@@ -98,7 +98,7 @@ spec:
     maxIterations: 8
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold
@@ -193,7 +193,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold
@@ -303,7 +303,7 @@ spec:
     maxIterations: 6
     maxTrafficPercentage: 80
   analysis:
-    analyticsService: "http://iter8-analytics.iter8"
+    analyticsService: "http://iter8-analytics.iter8:8080"
     successCriteria:
       - metricName: iter8_latency
         toleranceType: threshold

--- a/doc_files/iter8_crd.md
+++ b/doc_files/iter8_crd.md
@@ -45,8 +45,8 @@ spec:
     analysis:
 
       # analyticsService specifies analytics service endpoint (optional)
-      # default value is http://iter8-analytics.iter8
-      analyticsService: http://iter8-analytics.iter8
+      # default value is http://iter8-analytics.iter8:8080
+      analyticsService: http://iter8-analytics.iter8:8080
 
       # endpoint to Grafana dashboard (optional)
       # default is http://localhost:3000


### PR DESCRIPTION
Update doc to default of port 8080 for analytics engine
depends on https://github.com/iter8-tools/iter8-analytics/pull/54