### PR TITLE
Make documentation release-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The _iter8-controller_ currently uses the [Istio service mesh](https://istio.io)
 
 ## Installing iter8
 
-These [instructions](doc_files/iter8_install.md) will guide you to install the two iter8 components (_iter8-analytics_ and _iter8-controller_) on Kubernetes with Istio and/or Knative.
+These [instructions](doc_files/iter8_install.md) will guide you to install the two iter8 components (_iter8-analytics_ and _iter8-controller_) on Kubernetes with Istio.
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ To assess the behavior of microservice versions, iter8 supports a few metrics ou
 
 ## Supported environments
 
-The _iter8-controller_ currently supports the following Kubernetes-based environments, whose traffic-management capabilities are used:
-
-* [Istio service mesh](https://istio.io)
-* [Knative](https://knative.dev)
+The _iter8-controller_ currently uses the [Istio service mesh](https://istio.io) traffic management capabilities to automate the user traffic split across multiple microservice versions.
 
 ## Installing iter8
 
@@ -35,7 +32,6 @@ These [instructions](doc_files/iter8_install.md) will guide you to install the t
 The following tutorials will help you get started with iter8:
 
 * [Automated canary releases with iter8 on Kubernetes and Istio](doc_files/iter8_bookinfo_istio.md)
-* [Automated canary releases with iter8 on Knative](doc_files/iter8_bookinfo_knative.md)
 * [Automated canary release with iter8 on Kubernetes and Istio using Tekton](doc_files/iter8_tekton_task.md)
 
 ## Algorithms behind iter8
@@ -44,4 +40,6 @@ A key goal of this project is to introduce statistically robust algorithms for d
 
 ## Integrations
 
-Iter8 is integrated with [Tekton Pipelines](https://tekton.dev) for an end-to-end CI/CD experience, and with [KUI](https://www.kui.tools), for a richer Kubernetes command-line experience. Initial integrations with these two technologies already exist, but we are actively improving them. Stay tuned!
+Iter8 is integrated with [Tekton Pipelines](https://tekton.dev) for an end-to-end CI/CD experience, and with [KUI](https://www.kui.tools), for a richer Kubernetes command-line experience. Initial integrations with these two technologies already exist, but we are actively improving them.
+
+**The upcoming iter8 1.0.0 release will feature a deep integration with KUI. Stay tuned!**

--- a/doc_files/grafana.md
+++ b/doc_files/grafana.md
@@ -4,7 +4,7 @@ Different versions of Istio telemetry (`v1` or `v2`) report application-level me
 
 Below are instructions for each of these combinations. Choose only the instructions for the combination that matches your environment.
 
-### Istio telemetry v1 and Kubernetes prior to 1.16:
+### Istio _telemetry v1_ and _Kubernetes prior to 1.16_:
 
 Execute the following two commands:
 
@@ -15,7 +15,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-### Istio telemetry v2 and Kubernetes prior to 1.16:
+### Istio _telemetry v2_ and _Kubernetes prior to 1.16_:
 
 Execute the following two commands:
 
@@ -26,7 +26,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-### Istio telemetry v1 and Kubernetes 1.16 and later:
+### Istio _telemetry v1_ and _Kubernetes 1.16 and later_:
 
 Execute the following two commands:
 
@@ -37,7 +37,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-### Istio telemetry v2 and Kubernetes 1.16 and later:
+### Istio _telemetry v2_ and _Kubernetes 1.16 and later_:
 
 Execute the following two commands:
 

--- a/doc_files/grafana.md
+++ b/doc_files/grafana.md
@@ -1,0 +1,49 @@
+## Importing iter8's Grafana dashboard template
+
+Different versions of Istio telemetry (`v1` or `v2`) report application-level metrics differently. Similarly, since Kubernetes 1.16, cluster-level resource utilization metrics look slightly different on Prometheus. Therefore, depending on your combination of Istio telemetry and Kubernetes versions, you will need to populate Grafana with a specific iter8 Grafana dashboard template. 
+
+Below are instructions for each of these combinations. Choose only the instructions for the combination that matches your environment.
+
+#### Istio telemetry v1 and Kubernetes prior to 1.16
+
+Execute the following two commands:
+
+```bash
+export DASHBOARD_DEFN=https://github.com/iter8-tools/iter8-controller/releases/latest/download/istio-telemetry-v1.json
+
+curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download/grafana_install_dashboard.sh \
+| /bin/bash -
+```
+
+#### Istio telemetry v2 and Kubernetes prior to 1.16
+
+Execute the following two commands:
+
+```bash
+export DASHBOARD_DEFN=https://github.com/iter8-tools/iter8-controller/releases/latest/download/istio-telemetry-v2.json
+
+curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download/grafana_install_dashboard.sh \
+| /bin/bash -
+```
+
+#### Istio telemetry v1 and Kubernetes 1.16 and later
+
+Execute the following two commands:
+
+```bash
+export DASHBOARD_DEFN=https://github.com/iter8-tools/iter8-controller/releases/latest/download/istio-telemetry-v1-k8s-16.json
+
+curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download/grafana_install_dashboard.sh \
+| /bin/bash -
+```
+
+#### Istio telemetry v2 and Kubernetes 1.16 and later
+
+Execute the following two commands:
+
+```bash
+export DASHBOARD_DEFN=https://github.com/iter8-tools/iter8-controller/releases/latest/download/istio-telemetry-v2-k8s-16.json
+
+curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download/grafana_install_dashboard.sh \
+| /bin/bash -
+```

--- a/doc_files/grafana.md
+++ b/doc_files/grafana.md
@@ -4,7 +4,7 @@ Different versions of Istio telemetry (`v1` or `v2`) report application-level me
 
 Below are instructions for each of these combinations. Choose only the instructions for the combination that matches your environment.
 
-#### Istio telemetry v1 and Kubernetes prior to 1.16
+### Istio telemetry v1 and Kubernetes prior to 1.16:
 
 Execute the following two commands:
 
@@ -15,7 +15,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-#### Istio telemetry v2 and Kubernetes prior to 1.16
+### Istio telemetry v2 and Kubernetes prior to 1.16:
 
 Execute the following two commands:
 
@@ -26,7 +26,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-#### Istio telemetry v1 and Kubernetes 1.16 and later
+### Istio telemetry v1 and Kubernetes 1.16 and later:
 
 Execute the following two commands:
 
@@ -37,7 +37,7 @@ curl -s https://github.com/iter8-tools/iter8-controller/releases/latest/download
 | /bin/bash -
 ```
 
-#### Istio telemetry v2 and Kubernetes 1.16 and later
+### Istio telemetry v2 and Kubernetes 1.16 and later:
 
 Execute the following two commands:
 

--- a/doc_files/iter8_install.md
+++ b/doc_files/iter8_install.md
@@ -32,7 +32,7 @@ In case you need to customize the installation of iter8's latest release, use th
 
 ### Installing an older release
 
-In case you need to install an old iter8 release, please, refer to its corresponding documentation in the link below. In the URL below, you need to replace the string `<release>` with the string corresponding to your desired release. For example, a valid release string would be `v0.0.1`.
+In case you need to install an old iter8 release, please refer to its corresponding documentation in the link below. In the URL below, you need to replace the string `<release>` with the string corresponding to your desired release. For example, a valid release string would be `v0.0.1`.
 
 ```
 https://github.com/iter8-tools/docs/tree/<release>

--- a/doc_files/iter8_install.md
+++ b/doc_files/iter8_install.md
@@ -40,7 +40,7 @@ https://github.com/iter8-tools/docs/tree/<release>
 
 Note that the URL above points to the GitHub branch and tag corresponding to your desired release in the documentation repository.
 
-**Note on Prometheus:** In order to make assessments, _iter8_analytics_ needs to query metrics collected by Istio and stored on Prometheus. The default values for the helm chart parameters (used in the quick installation) point _iter8_analytics_ to Prometheus at `http://prometheus.istio-system:9090`, which is the default internal Kubernetes URL of Prometheus installed as an Istio addon. If your Istio installation is shipping metrics to a different Prometheus installation, you need to set the _iter8-analytics_ Helm chart parameter `iter8Config.metricsBackendURL` to your Prometheus `host:port`.
+**Note on Prometheus:** In order to make assessments, _iter8_analytics_ needs to query metrics collected by Istio and stored on Prometheus. The default values for the helm chart parameters (used in the quick installation) point _iter8_analytics_ to Prometheus at `http://prometheus.istio-system:9090` (the default internal Kubernetes URL of Prometheus installed as an Istio addon) without specifying the need for authentication. If your Istio installation is shipping metrics to a different Prometheus installation, or if you need to configure authentication to access Prometheus, you need to set appropriate _iter8-analytics_ Helm chart parameters. Look for the Prometheus-related parameters in the _iter8-analytics_ Helm chart's `values.yaml` file.
 
 ### Verify the installation
 

--- a/doc_files/iter8_install.md
+++ b/doc_files/iter8_install.md
@@ -1,52 +1,46 @@
 # Iter8 on Kubernetes and Istio
 
-These instructions show you how to set up iter8 on Kubernetes with Istio or with Knative.
+These instructions show you how to set up iter8 on Kubernetes with Istio.
 
 ## Prerequisites
 
 * Kubernetes v1.11 or newer.
-
-If you want to use iter8 with Istio, we require:
-
 * Istio v1.1.5 and newer.
 * Your Istio installation must have at least the **istio-pilot** as well as **telemetry** and **Prometheus** enabled.
 
-If you want to use iter8 with Knative, we require:
-
-* [Knative 0.6](https://knative.dev/docs/install/) or newer.
-
 ## Install iter8 on Kubernetes
 
-### Quick installation
+iter8 has two components, _iter8_analytics_ and _iter8_controller_. To install them, follow these instructions.
 
-iter8 has two components, _iter8_analytics_ and _iter8_controller_. These can be installed for use with Istio as follows:
+### Quick installation (latest release)
 
-```bash
-kubectl apply \
-    -f https://raw.githubusercontent.com/iter8-tools/iter8-analytics/master/install/kubernetes/iter8-analytics.yaml \
-    -f https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/install/iter8-controller.yaml 
-```
-
-To install for use with knative, modify the first file:
+To install the latest iter8 release with the default settings, you can apply the default yaml files for _iter8-analytics_ and _iter8-controller_ by running the following command:
 
 ```bash
 kubectl apply \
-    -f https://raw.githubusercontent.com/iter8-tools/iter8-analytics/master/install/knative/iter8-analytics.yaml \
-    -f https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/install/iter8-controller.yaml 
+    -f https://github.com/iter8-tools/iter8-analytics/releases/latest/download/iter8-analytics.yaml \
+    -f https://github.com/iter8-tools/iter8-controller/releases/latest/download/iter8-controller.yaml
 ```
 
-### Customized installation
+### Customized installation via Helm charts (latest release)
 
-In case you need to change the default configuration options used in the quick installation, use the helm charts directly by cloning the projects:
+In case you need to customize the installation of iter8's latest release, use the Helm charts listed below:
 
-```bash
-git clone git@github.com:iter8-tools/iter8-analytics.git
-git clone git@github.com:iter8-tools/iter8-controller.git
+* _iter8-analytics_: [https://github.com/iter8-tools/iter8-analytics/releases/latest/download/iter8-analytics-helm-chart.tar](https://github.com/iter8-tools/iter8-analytics/releases/latest/download/iter8-analytics-helm-chart.tar)
+
+* _iter8-controller_: [https://github.com/iter8-tools/iter8-controller/releases/latest/download/iter8-controller-helm-chart.tar](https://github.com/iter8-tools/iter8-controller/releases/latest/download/iter8-controller-helm-chart.tar)
+
+### Installing an older release
+
+In case you need to install an old iter8 release, please, refer to its corresponding documentation in the link below. In the URL below, you need to replace the string `<release>` with the string corresponding to your desired release. For example, a valid release string would be `v0.0.1`.
+
+```
+https://github.com/iter8-tools/docs/tree/<release>
 ```
 
-The _iter8-analytics_ helm chart is [here](https://github.com/iter8-tools/iter8-analytics/tree/master/install/kubernetes/helm/iter8-analytics), and the _iter8-controller_ helm chart is [here](https://github.com/iter8-tools/iter8-controller/tree/master/install/helm/iter8-controller).
+Note that the URL above points to the GitHub branch and tag corresponding to your desired release in the documentation repository.
 
-**Note on Prometheus:** In order to make assessments on canary releases, _iter8_analytics_ needs to query metrics collected by Istio and stored on Prometheus. The default values for the helm chart parameters (used in the quick installation) point _iter8_analytics_ to Prometheus at `http://prometheus.istio-system:9090`, which is the default internal Kubernetes URL of Prometheus installed as an Istio addon. If your Istio installation is shipping metrics to a different Prometheus installation, you need to set the _iter8-analytics_ helm chart parameter `iter8Config.metricsBackendURL` to your Prometheus `host:port`.
+**Note on Prometheus:** In order to make assessments, _iter8_analytics_ needs to query metrics collected by Istio and stored on Prometheus. The default values for the helm chart parameters (used in the quick installation) point _iter8_analytics_ to Prometheus at `http://prometheus.istio-system:9090`, which is the default internal Kubernetes URL of Prometheus installed as an Istio addon. If your Istio installation is shipping metrics to a different Prometheus installation, you need to set the _iter8-analytics_ Helm chart parameter `iter8Config.metricsBackendURL` to your Prometheus `host:port`.
 
 ### Verify the installation
 
@@ -68,7 +62,7 @@ iter8-analytics              ClusterIP   172.21.106.44   <none>        80/TCP   
 
 ### Import iter8's Grafana dashboard
 
-To enable users to see Prometheus metrics that pertain to their canary releases, iter8 provides a Grafana dashboard template. To take advantage of Grafana, you will need to import this template. To do so, first make sure you can access Grafana. In a typical Istio installation, you can port-forward Grafana from Kubernetes to your localhost's port 3000 with the command below:
+To enable users to see Prometheus metrics that pertain to their canary releases or A/B tests, iter8 provides a Grafana dashboard template. To take advantage of Grafana, you will need to import this template. To do so, first make sure you can access Grafana. In a typical Istio installation, you can port-forward Grafana from Kubernetes to your localhost's port 3000 with the command below:
 
 ```bash
 kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000
@@ -76,30 +70,16 @@ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=gr
 
 After running that command, you can access Grafana's UI at `http://localhost:3000`.
 
-To import iter8's dashboard template for Istio, execute the following two commands:
-
-```bash
-export DASHBOARD_DEFN=https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/istio.json
-
-curl -s https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/hack/grafana_install_dashboard.sh \
-| /bin/bash -
-```
-
-If you are using iter8 with Knative, use these two commands instead:
-
-```bash
-export DASHBOARD_DEFN=https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/config/grafana/knative.json
-
-curl -s https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/hack/grafana_install_dashboard.sh \
-| /bin/bash -
-```
+Depending on the version of Istio telemetry (`v1` or `v2`) and Kubernetes (prior to 1.16 and 1.16+) you are using, you will need to import a different Grafana dashboard. Follow [these instructions](grafana.md) to import the appropriate dashboard template.
 
 ## Uninstall _iter8_
 
-If you want to uninstall all _iter8_ components from your Kubernetes cluster, first delete all instances of `Experiment` from all namespaces. Then you can delete iter8 by running the following command:
+If you want to uninstall all _iter8_ components from your Kubernetes cluster, first delete all instances of `Experiment` from all namespaces. Then, you can delete iter8 by running the following command, adjusting the URL based on the release you are uninstalling.
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/iter8-tools/iter8-controller/master/install/iter8-controller.yaml
+kubectl delete -f https://raw.githubusercontent.com/iter8-tools/iter8-controller/<release>/install/iter8-controller.yaml
 ```
+
+In the URL above, replace the string `<release>` with the string for your desired release. For example, a valid release string is `v0.0.1`.
 
 Note that this command will delete the `Experiment` CRD and wipe out the `iter8` namespace, but it will not remove the iter8 Grafana dashboard if created.


### PR DESCRIPTION
This PR intends to make the documentation on the master branch aware of the fact that there are different iter8 releases available. In particular, it references installation artifacts for the latest release, and documents how older releases can be installed.

Furthermore, this PR removes references to Knative from the documentation.

Finally, this PR includes documentation for users to choose the appropriate Grafana dashboard depending on the version of Istio telemetry or K8s they are using.