### PR TITLE
re-enable copy to clipboard

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   # Default values, taken from mkdocs_theme.yml
   language: en
   features:
+  - content.code.copy
   - navigation.instant
   - navigation.sections
   - navigation.tabs

--- a/samples/abn-sample/generate_load.sh
+++ b/samples/abn-sample/generate_load.sh
@@ -8,13 +8,13 @@ BUY="$SERVICE/buy"
 while (( 1 )); do 
     __user=$(uuidgen)
     __num_purchases=$(( ( RANDOM % 5 ) +1 ))
-    j=0
-    while (( ${j} < ${__num_purchases} )); do
+    j=1
+    while (( ${j} <= ${__num_purchases} )); do
         echo "purchase $j of $__num_purchases for user $__user"
         __num_recommendations=$(( ( RANDOM % 5 )  + 1 ))
         # get some recommendations
-        i=0
-        while (( ${i} < ${__num_recommendations} )); do
+        i=1
+        while (( ${i} <= ${__num_recommendations} )); do
             echo "> recommendation $i of $__num_recommendations"
             curl -s ${GET_RECOMMENDATION} -H "X-User: ${__user}"
             sleep $(( ( RANDOM % 2000 ) / 1000 ))


### PR DESCRIPTION
needs to be explicit configuration in mkdocs.yml since update to v9